### PR TITLE
Using Uniswap LP tokens as collateral

### DIFF
--- a/contracts/external/uniswap/Math.sol
+++ b/contracts/external/uniswap/Math.sol
@@ -6,15 +6,15 @@ pragma solidity ^0.7.0;
 // a library for performing various math operations
 
 library Math {
-    function min(uint x, uint y) internal pure returns (uint z) {
+    function min(uint256 x, uint256 y) internal pure returns (uint256 z) {
         z = x < y ? x : y;
     }
 
     // babylonian method (https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Babylonian_method)
-    function sqrt(uint y) internal pure returns (uint z) {
+    function sqrt(uint256 y) internal pure returns (uint256 z) {
         if (y > 3) {
             z = y;
-            uint x = y / 2 + 1;
+            uint256 x = y / 2 + 1;
             while (x < z) {
                 z = x;
                 x = (y / x + x) / 2;

--- a/contracts/external/uniswap/Math.sol
+++ b/contracts/external/uniswap/Math.sol
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+pragma solidity ^0.7.0;
+
+// https://github.com/Uniswap/uniswap-v2-core/blob/master/contracts/libraries/Math.sol
+
+// a library for performing various math operations
+
+library Math {
+    function min(uint x, uint y) internal pure returns (uint z) {
+        z = x < y ? x : y;
+    }
+
+    // babylonian method (https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Babylonian_method)
+    function sqrt(uint y) internal pure returns (uint z) {
+        if (y > 3) {
+            z = y;
+            uint x = y / 2 + 1;
+            while (x < z) {
+                z = x;
+                x = (y / x + x) / 2;
+            }
+        } else if (y != 0) {
+            z = 1;
+        }
+    }
+}

--- a/contracts/external/uniswap/UniswapV2PairInterface.sol
+++ b/contracts/external/uniswap/UniswapV2PairInterface.sol
@@ -1,69 +1,14 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 pragma solidity ^0.7.0;
 
-// https://github.com/Uniswap/uniswap-v2-core/blob/master/contracts/interfaces/IUniswapV2Pair.sol
-
+/**
+ * @title UniswapV2PairInterface
+ * @author Hifi
+ * @dev Forked from Uniswap
+ * https://github.com/Uniswap/uniswap-v2-core/blob/master/contracts/interfaces/IUniswapV2Pair.sol
+ */
 interface UniswapV2PairInterface {
-    event Approval(address indexed owner, address indexed spender, uint256 value);
-    event Transfer(address indexed from, address indexed to, uint256 value);
-
-    function name() external pure returns (string memory);
-
-    function symbol() external pure returns (string memory);
-
-    function decimals() external pure returns (uint8);
-
     function totalSupply() external view returns (uint256);
-
-    function balanceOf(address owner) external view returns (uint256);
-
-    function allowance(address owner, address spender) external view returns (uint256);
-
-    function approve(address spender, uint256 value) external returns (bool);
-
-    function transfer(address to, uint256 value) external returns (bool);
-
-    function transferFrom(
-        address from,
-        address to,
-        uint256 value
-    ) external returns (bool);
-
-    function DOMAIN_SEPARATOR() external view returns (bytes32);
-
-    function PERMIT_TYPEHASH() external pure returns (bytes32);
-
-    function nonces(address owner) external view returns (uint256);
-
-    function permit(
-        address owner,
-        address spender,
-        uint256 value,
-        uint256 deadline,
-        uint8 v,
-        bytes32 r,
-        bytes32 s
-    ) external;
-
-    event Mint(address indexed sender, uint256 amount0, uint256 amount1);
-    event Burn(address indexed sender, uint256 amount0, uint256 amount1, address indexed to);
-    event Swap(
-        address indexed sender,
-        uint256 amount0In,
-        uint256 amount1In,
-        uint256 amount0Out,
-        uint256 amount1Out,
-        address indexed to
-    );
-    event Sync(uint112 reserve0, uint112 reserve1);
-
-    function MINIMUM_LIQUIDITY() external pure returns (uint256);
-
-    function factory() external view returns (address);
-
-    function token0() external view returns (address);
-
-    function token1() external view returns (address);
 
     function getReserves()
         external
@@ -73,27 +18,4 @@ interface UniswapV2PairInterface {
             uint112 reserve1,
             uint32 blockTimestampLast
         );
-
-    function price0CumulativeLast() external view returns (uint256);
-
-    function price1CumulativeLast() external view returns (uint256);
-
-    function kLast() external view returns (uint256);
-
-    function mint(address to) external returns (uint256 liquidity);
-
-    function burn(address to) external returns (uint256 amount0, uint256 amount1);
-
-    function swap(
-        uint256 amount0Out,
-        uint256 amount1Out,
-        address to,
-        bytes calldata data
-    ) external;
-
-    function skim(address to) external;
-
-    function sync() external;
-
-    function initialize(address, address) external;
 }

--- a/contracts/external/uniswap/UniswapV2PairInterface.sol
+++ b/contracts/external/uniswap/UniswapV2PairInterface.sol
@@ -1,0 +1,99 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+pragma solidity ^0.7.0;
+
+// https://github.com/Uniswap/uniswap-v2-core/blob/master/contracts/interfaces/IUniswapV2Pair.sol
+
+interface UniswapV2PairInterface {
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    function name() external pure returns (string memory);
+
+    function symbol() external pure returns (string memory);
+
+    function decimals() external pure returns (uint8);
+
+    function totalSupply() external view returns (uint256);
+
+    function balanceOf(address owner) external view returns (uint256);
+
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    function approve(address spender, uint256 value) external returns (bool);
+
+    function transfer(address to, uint256 value) external returns (bool);
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 value
+    ) external returns (bool);
+
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+
+    function PERMIT_TYPEHASH() external pure returns (bytes32);
+
+    function nonces(address owner) external view returns (uint256);
+
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    event Mint(address indexed sender, uint256 amount0, uint256 amount1);
+    event Burn(address indexed sender, uint256 amount0, uint256 amount1, address indexed to);
+    event Swap(
+        address indexed sender,
+        uint256 amount0In,
+        uint256 amount1In,
+        uint256 amount0Out,
+        uint256 amount1Out,
+        address indexed to
+    );
+    event Sync(uint112 reserve0, uint112 reserve1);
+
+    function MINIMUM_LIQUIDITY() external pure returns (uint256);
+
+    function factory() external view returns (address);
+
+    function token0() external view returns (address);
+
+    function token1() external view returns (address);
+
+    function getReserves()
+        external
+        view
+        returns (
+            uint112 reserve0,
+            uint112 reserve1,
+            uint32 blockTimestampLast
+        );
+
+    function price0CumulativeLast() external view returns (uint256);
+
+    function price1CumulativeLast() external view returns (uint256);
+
+    function kLast() external view returns (uint256);
+
+    function mint(address to) external returns (uint256 liquidity);
+
+    function burn(address to) external returns (uint256 amount0, uint256 amount1);
+
+    function swap(
+        uint256 amount0Out,
+        uint256 amount1Out,
+        address to,
+        bytes calldata data
+    ) external;
+
+    function skim(address to) external;
+
+    function sync() external;
+
+    function initialize(address, address) external;
+}

--- a/contracts/oracles/UniswapV2PairPriceFeed.sol
+++ b/contracts/oracles/UniswapV2PairPriceFeed.sol
@@ -112,8 +112,8 @@ contract UniswapV2PairPriceFeed is AggregatorV3Interface, CarefulMath {
         (, vars.p0, , , ) = underlyingOracles[0].latestRoundData();
         (, vars.p1, , , ) = underlyingOracles[1].latestRoundData();
 
-        (vars.mathErr, vars.k) = mulUInt(vars.r0, vars.r1);
-        require(vars.mathErr == MathError.NO_ERROR, "ERR_LATEST_ROUND_DATA_MATH_ERROR");
+        /* Will never overflow since types(uint112).max * types(uint112).max can fit into a uint256 */
+        (, vars.k) = mulUInt(vars.r0, vars.r1);
 
         vars.sqrtK = Math.sqrt(vars.k);
 

--- a/contracts/oracles/UniswapV2PairPriceFeed.sol
+++ b/contracts/oracles/UniswapV2PairPriceFeed.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.7.0;
 
 /*
     Inspired by Alpha Finance's Fair Uniswap's LP Token Pricing
+    https://blog.alphafinance.io/fair-lp-token-pricing
     https://github.com/AlphaFinanceLab/homora-v2/blob/master/contracts/oracle/UniswapV2Oracle.sol
 */
 

--- a/contracts/oracles/UniswapV2PairPriceFeed.sol
+++ b/contracts/oracles/UniswapV2PairPriceFeed.sol
@@ -26,22 +26,22 @@ contract UniswapV2PairPriceFeed is AggregatorV3Interface, CarefulMath {
     UniswapV2PairInterface public pair;
 
     /**
-     * @notice ETH-quoted Chainlink oracles for underlying paired assets.
+     * @notice USD-quoted Chainlink oracles for underlying paired assets.
      */
     AggregatorV3Interface[] public underlyingOracles;
 
     constructor(
+        string memory description_,
         UniswapV2PairInterface pair_,
-        AggregatorV3Interface[] memory underlyingOracles_,
-        string memory description_
+        AggregatorV3Interface[] memory underlyingOracles_
     ) {
+        internalDescription = description_;
         pair = pair_;
         underlyingOracles = underlyingOracles_;
-        internalDescription = description_;
     }
 
     function decimals() external pure override returns (uint8) {
-        return 18;
+        return 8;
     }
 
     function description() external view override returns (string memory) {
@@ -101,7 +101,7 @@ contract UniswapV2PairPriceFeed is AggregatorV3Interface, CarefulMath {
 
     /**
      * @notice Get the latest price of the LP token.
-     * @return The price of the LP token quoted in ETH (18 decimals).
+     * @return The price of the LP token quoted in USD (8 decimals).
      */
     function getPriceInternal() internal view returns (int256) {
         GetPriceInternalLocalVars memory vars;

--- a/contracts/oracles/UniswapV2PairPriceFeed.sol
+++ b/contracts/oracles/UniswapV2PairPriceFeed.sol
@@ -113,7 +113,7 @@ contract UniswapV2PairPriceFeed is AggregatorV3Interface, CarefulMath {
         (, vars.p1, , , ) = underlyingOracles[1].latestRoundData();
 
         /* Will never overflow since types(uint112).max * types(uint112).max can fit into a uint256 */
-        (, vars.k) = mulUInt(vars.r0, vars.r1);
+        (, vars.k) = mulUInt(uint256(vars.r0), uint256(vars.r1));
 
         vars.sqrtK = Math.sqrt(vars.k);
 
@@ -130,6 +130,8 @@ contract UniswapV2PairPriceFeed is AggregatorV3Interface, CarefulMath {
 
         (vars.mathErr, vars.price) = divUInt(vars.dividend, vars.divisor);
         require(vars.mathErr == MathError.NO_ERROR, "ERR_LATEST_ROUND_DATA_MATH_ERROR");
+
+        assert(vars.price < uint256(type(int256).max));
 
         return int256(vars.price);
     }

--- a/contracts/oracles/UniswapV2PairPriceFeed.sol
+++ b/contracts/oracles/UniswapV2PairPriceFeed.sol
@@ -50,7 +50,7 @@ contract UniswapV2PairPriceFeed is AggregatorV3Interface, CarefulMath {
         return 1;
     }
 
-    function getRoundData(uint80)
+    function getRoundData(uint80 _roundId)
         external
         view
         override
@@ -62,6 +62,7 @@ contract UniswapV2PairPriceFeed is AggregatorV3Interface, CarefulMath {
             uint80 answeredInRound
         )
     {
+        require(_roundId == 0, "ERR_GET_ROUND_DATA_NO_HISTORIC_ROUNDS");
         return this.latestRoundData();
     }
 

--- a/contracts/oracles/UniswapV2PairPriceFeed.sol
+++ b/contracts/oracles/UniswapV2PairPriceFeed.sol
@@ -70,8 +70,8 @@ contract UniswapV2PairPriceFeed is AggregatorV3Interface, CarefulMath {
         uint256 divisor;
         uint256 r0;
         uint256 r1;
-        uint256 r0r1;
-        uint256 sqrtR0R1;
+        uint256 k;
+        uint256 sqrtK;
         int256 p0;
         int256 p1;
         uint256 p0p1;
@@ -101,17 +101,17 @@ contract UniswapV2PairPriceFeed is AggregatorV3Interface, CarefulMath {
         (, vars.p0, , , ) = token0Oracle.latestRoundData();
         (, vars.p1, , , ) = token1Oracle.latestRoundData();
 
-        (vars.mathErr, vars.r0r1) = mulUInt(vars.r0, vars.r1);
+        (vars.mathErr, vars.k) = mulUInt(vars.r0, vars.r1);
         require(vars.mathErr == MathError.NO_ERROR, "ERR_LATEST_ROUND_DATA_MATH_ERROR");
 
-        vars.sqrtR0R1 = Math.sqrt(vars.r0r1);
+        vars.sqrtK = Math.sqrt(vars.k);
 
         (vars.mathErr, vars.p0p1) = mulUInt(uint256(vars.p0), uint256(vars.p1));
         require(vars.mathErr == MathError.NO_ERROR, "ERR_LATEST_ROUND_DATA_MATH_ERROR");
 
         vars.sqrtP0P1 = Math.sqrt(vars.p0p1);
 
-        (vars.mathErr, vars.sqrtR0R1sqrtP0P1) = mulUInt(vars.sqrtR0R1, vars.sqrtP0P1);
+        (vars.mathErr, vars.sqrtR0R1sqrtP0P1) = mulUInt(vars.sqrtK, vars.sqrtP0P1);
         require(vars.mathErr == MathError.NO_ERROR, "ERR_LATEST_ROUND_DATA_MATH_ERROR");
 
         (vars.mathErr, vars.dividend) = mulUInt(vars.sqrtR0R1sqrtP0P1, 2);

--- a/contracts/oracles/UniswapV2PairPriceFeed.sol
+++ b/contracts/oracles/UniswapV2PairPriceFeed.sol
@@ -1,0 +1,124 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+pragma solidity ^0.7.0;
+
+/*
+    Inspired by Alpha Finance's Fair Uniswap's LP Token Pricing
+    https://github.com/AlphaFinanceLab/homora-v2/blob/master/contracts/oracle/UniswapV2Oracle.sol
+*/
+
+import "../external/uniswap/UniswapV2PairInterface.sol";
+import "../external/uniswap/Math.sol";
+import "@paulrberg/contracts/math/CarefulMath.sol";
+import "../external/chainlink/AggregatorV3Interface.sol";
+
+/**
+ * @title UniswapV2PairPriceFeed
+ * @author Hifi
+ */
+contract UniswapV2PairPriceFeed is AggregatorV3Interface, CarefulMath {
+    string internal internalDescription;
+
+    // UniswapV2Pair
+    UniswapV2PairInterface public pair;
+
+    // ETH-quoted Chainlink oracles
+    AggregatorV3Interface public token0Oracle;
+    AggregatorV3Interface public token1Oracle;
+
+    constructor(
+        UniswapV2PairInterface pair_,
+        AggregatorV3Interface token0Oracle_,
+        AggregatorV3Interface token1Oracle_,
+        string memory description_
+    ) {
+        pair = pair_;
+        token0Oracle = token0Oracle_;
+        token1Oracle = token1Oracle_;
+        internalDescription = description_;
+    }
+
+    function decimals() external pure override returns (uint8) {
+        return 18;
+    }
+
+    function description() external view override returns (string memory) {
+        return internalDescription;
+    }
+
+    function version() external pure override returns (uint256) {
+        return 1;
+    }
+
+    function getRoundData(uint80)
+        external
+        view
+        override
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        )
+    {
+        return this.latestRoundData();
+    }
+
+    struct LatestRoundDataLocalVars {
+        MathError mathErr;
+        uint256 divisor;
+        uint256 r0;
+        uint256 r1;
+        uint256 r0r1;
+        uint256 sqrtR0R1;
+        int256 p0;
+        int256 p1;
+        uint256 p0p1;
+        uint256 sqrtP0P1;
+        uint256 sqrtR0R1sqrtP0P1;
+        uint256 dividend;
+        uint256 price;
+    }
+
+    function latestRoundData()
+        external
+        view
+        override
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        )
+    {
+        LatestRoundDataLocalVars memory vars;
+
+        vars.divisor = UniswapV2PairInterface(pair).totalSupply();
+        (vars.r0, vars.r1, ) = UniswapV2PairInterface(pair).getReserves();
+
+        (, vars.p0, , , ) = token0Oracle.latestRoundData();
+        (, vars.p1, , , ) = token1Oracle.latestRoundData();
+
+        (vars.mathErr, vars.r0r1) = mulUInt(vars.r0, vars.r1);
+        require(vars.mathErr == MathError.NO_ERROR, "ERR_LATEST_ROUND_DATA_MATH_ERROR");
+
+        vars.sqrtR0R1 = Math.sqrt(vars.r0r1);
+
+        (vars.mathErr, vars.p0p1) = mulUInt(uint256(vars.p0), uint256(vars.p1));
+        require(vars.mathErr == MathError.NO_ERROR, "ERR_LATEST_ROUND_DATA_MATH_ERROR");
+
+        vars.sqrtP0P1 = Math.sqrt(vars.p0p1);
+
+        (vars.mathErr, vars.sqrtR0R1sqrtP0P1) = mulUInt(vars.sqrtR0R1, vars.sqrtP0P1);
+        require(vars.mathErr == MathError.NO_ERROR, "ERR_LATEST_ROUND_DATA_MATH_ERROR");
+
+        (vars.mathErr, vars.dividend) = mulUInt(vars.sqrtR0R1sqrtP0P1, 2);
+        require(vars.mathErr == MathError.NO_ERROR, "ERR_LATEST_ROUND_DATA_MATH_ERROR");
+
+        (vars.mathErr, vars.price) = divUInt(vars.dividend, vars.divisor);
+        require(vars.mathErr == MathError.NO_ERROR, "ERR_LATEST_ROUND_DATA_MATH_ERROR");
+
+        return (0, int256(vars.price), 0, block.timestamp, 0);
+    }
+}

--- a/contracts/test/SimpleUniswapV2Pair.sol
+++ b/contracts/test/SimpleUniswapV2Pair.sol
@@ -1,0 +1,45 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+pragma solidity ^0.7.0;
+
+import "../external/uniswap/UniswapV2PairInterface.sol";
+
+/**
+ * @title SimplePriceFeed
+ * @author Hifi
+ */
+contract SimpleUniswapV2Pair is UniswapV2PairInterface {
+    uint256 internal totalSupplyInternal;
+    uint112 internal reserve0;
+    uint112 internal reserve1;
+    uint256 internal blockTimestampLast;
+
+    function totalSupply() external view override returns (uint256) {
+        return totalSupplyInternal;
+    }
+
+    function getReserves()
+        external
+        view
+        override
+        returns (
+            uint112 _reserve0,
+            uint112 _reserve1,
+            uint32 _blockTimestampLast
+        )
+    {
+        _reserve0 = reserve0;
+        _reserve1 = reserve1;
+        _blockTimestampLast = uint32(block.timestamp);
+    }
+
+    function update(
+        uint112 _reserve0,
+        uint112 _reserve1,
+        uint256 _totalSupply
+    ) public {
+        totalSupplyInternal = _totalSupply;
+        reserve0 = _reserve0;
+        reserve1 = _reserve1;
+        blockTimestampLast = block.timestamp;
+    }
+}

--- a/contracts/test/SimpleUniswapV2PairPriceFeed.sol
+++ b/contracts/test/SimpleUniswapV2PairPriceFeed.sol
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+pragma solidity ^0.7.0;
+
+import "./SimpleUniswapV2Pair.sol";
+import "../external/uniswap/UniswapV2PairInterface.sol";
+import "../external/chainlink/AggregatorV3Interface.sol";
+
+/**
+ * @title SimplePriceFeed
+ * @author Hifi
+ */
+contract SimpleUniswapV2PairPriceFeed is SimpleUniswapV2Pair {
+    string internal internalDescription;
+
+    /**
+     * @notice The Uniswap pair contract.
+     */
+    UniswapV2PairInterface public pair;
+
+    /**
+     * @notice USD-quoted Chainlink oracles for underlying paired assets.
+     */
+    AggregatorV3Interface[] public underlyingOracles;
+
+    constructor(
+        UniswapV2PairInterface pair_,
+        AggregatorV3Interface[] memory underlyingOracles_,
+        string memory description_
+    ) {
+        pair = pair_;
+        underlyingOracles = underlyingOracles_;
+        internalDescription = description_;
+    }
+}

--- a/helpers/errors.ts
+++ b/helpers/errors.ts
@@ -25,6 +25,11 @@ export enum ChainlinkOperatorErrors {
   PriceZero = "ERR_PRICE_ZERO",
 }
 
+export enum UniswapV2PairPriceFeedErrors {
+  GetRoundDataNoHistoricRounds = "ERR_GET_ROUND_DATA_NO_HISTORIC_ROUNDS",
+  LatestRoundDataMathError = "ERR_LATEST_ROUND_DATA_MATH_ERROR",
+}
+
 export enum FintrollerErrors {
   BondNotListed = "ERR_BOND_NOT_LISTED",
   ListBondFyTokenInspection = "ERR_LIST_BOND_FYTOKEN_INSPECTION",

--- a/test/deployers.ts
+++ b/test/deployers.ts
@@ -154,17 +154,6 @@ export async function deployUnderlyingPriceFeed(deployer: Signer): Promise<Simpl
   return underlyingPriceFeed;
 }
 
-export async function deployUnderlyingPriceFeeds(deployer: Signer): Promise<SimplePriceFeed[]> {
-  const simpleEthQuotedPriceFeedArtifact: Artifact = await hre.artifacts.readArtifact("SimplePriceFeed");
-  const underlyingPriceFeeds: SimplePriceFeed[] = <SimplePriceFeed[]>[
-    await deployContract(deployer, simpleEthQuotedPriceFeedArtifact, ["WBTC/ETH"], overrideOptions),
-    await deployContract(deployer, simpleEthQuotedPriceFeedArtifact, ["UNI/ETH"], overrideOptions),
-  ];
-  await underlyingPriceFeeds[0].setPrice(prices.oneHundredDollars);
-  await underlyingPriceFeeds[1].setPrice(prices.twelveDollars);
-  return underlyingPriceFeeds;
-}
-
 export async function deployUniswapV2PairPriceFeed(
   deployer: Signer,
   description: string,

--- a/test/deployers.ts
+++ b/test/deployers.ts
@@ -12,6 +12,7 @@ import { GodModeBalanceSheet } from "../typechain/GodModeBalanceSheet";
 import { GodModeRedemptionPool } from "../typechain/GodModeRedemptionPool";
 import { GodModeFyToken } from "../typechain/GodModeFyToken";
 import { SimplePriceFeed } from "../typechain/SimplePriceFeed";
+import { UniswapV2PairPriceFeed } from "../typechain/UniswapV2PairPriceFeed";
 import { fyTokenConstants, gasLimits, prices } from "../helpers/constants";
 
 const overrideOptions: TransactionRequest = {
@@ -151,4 +152,33 @@ export async function deployUnderlyingPriceFeed(deployer: Signer): Promise<Simpl
   );
   await underlyingPriceFeed.setPrice(prices.oneDollar);
   return underlyingPriceFeed;
+}
+
+export async function deployUnderlyingPriceFeeds(deployer: Signer): Promise<SimplePriceFeed[]> {
+  const simpleEthQuotedPriceFeedArtifact: Artifact = await hre.artifacts.readArtifact("SimplePriceFeed");
+  const underlyingPriceFeeds: SimplePriceFeed[] = <SimplePriceFeed[]>[
+    await deployContract(deployer, simpleEthQuotedPriceFeedArtifact, ["WBTC/ETH"], overrideOptions),
+    await deployContract(deployer, simpleEthQuotedPriceFeedArtifact, ["UNI/ETH"], overrideOptions),
+  ];
+  await underlyingPriceFeeds[0].setPrice(prices.oneHundredDollars);
+  await underlyingPriceFeeds[1].setPrice(prices.twelveDollars);
+  return underlyingPriceFeeds;
+}
+
+export async function deployUniswapV2PairPriceFeed(
+  deployer: Signer,
+  description: string,
+  pair: string,
+  underlyingOracles: string[],
+): Promise<UniswapV2PairPriceFeed> {
+  const uniswapV2PairPriceFeedArtifact: Artifact = await hre.artifacts.readArtifact("UniswapV2PairPriceFeed");
+  const uniswapV2PairPriceFeed: UniswapV2PairPriceFeed = <UniswapV2PairPriceFeed>(
+    await deployContract(
+      deployer,
+      uniswapV2PairPriceFeedArtifact,
+      [description, pair, underlyingOracles],
+      overrideOptions,
+    )
+  );
+  return uniswapV2PairPriceFeed;
 }

--- a/test/unit/fixtures.ts
+++ b/test/unit/fixtures.ts
@@ -7,6 +7,7 @@ import { Fintroller } from "../../typechain/Fintroller";
 import { GodModeBalanceSheet } from "../../typechain/GodModeBalanceSheet";
 import { GodModeFyToken } from "../../typechain/GodModeFyToken";
 import { GodModeRedemptionPool } from "../../typechain/GodModeRedemptionPool";
+import { UniswapV2PairPriceFeed } from "../../typechain/UniswapV2PairPriceFeed";
 
 import {
   deployChainlinkOperator,
@@ -14,6 +15,8 @@ import {
   deployGodModeBalanceSheet,
   deployGodModeFyToken,
   deployGodModeRedemptionPool,
+  deployUniswapV2PairPriceFeed,
+  deployUnderlyingPriceFeeds,
 } from "../deployers";
 import {
   deployStubBalanceSheet,
@@ -24,8 +27,31 @@ import {
   deployStubRedemptionPool,
   deployStubFyToken,
   deployStubUnderlying,
+  deployStubUniswapV2Pair,
 } from "./stubs";
 import { fyTokenConstants } from "../../helpers/constants";
+
+type UnitFixtureUniswapV2PairPriceFeedReturnType = {
+  uniswapV2PairPriceFeed: UniswapV2PairPriceFeed;
+  uniswapV2Pair: MockContract;
+}
+
+export async function unitFixtureUniswapV2PairPriceFeed(signers: Signer[]): Promise<UnitFixtureUniswapV2PairPriceFeedReturnType> {
+  const deployer: Signer = signers[0];
+
+  const uniswapV2Pair: MockContract = await deployStubUniswapV2Pair(deployer);
+
+  const underlyingOracles = await deployUnderlyingPriceFeeds(deployer);
+
+  const uniswapV2PairPriceFeed: UniswapV2PairPriceFeed = await deployUniswapV2PairPriceFeed(
+    deployer,
+    'WBTC-UNI/ETH',
+    uniswapV2Pair.address,
+    [underlyingOracles[0].address, underlyingOracles[1].address],
+  );
+
+  return { uniswapV2PairPriceFeed, uniswapV2Pair };
+}
 
 type UnitFixtureBalanceSheetReturnType = {
   balanceSheet: GodModeBalanceSheet;

--- a/test/unit/fixtures.ts
+++ b/test/unit/fixtures.ts
@@ -16,7 +16,6 @@ import {
   deployGodModeFyToken,
   deployGodModeRedemptionPool,
   deployUniswapV2PairPriceFeed,
-  deployUnderlyingPriceFeeds,
 } from "../deployers";
 import {
   deployStubBalanceSheet,
@@ -28,29 +27,33 @@ import {
   deployStubFyToken,
   deployStubUnderlying,
   deployStubUniswapV2Pair,
+  deployStubPriceFeed,
 } from "./stubs";
 import { fyTokenConstants } from "../../helpers/constants";
 
 type UnitFixtureUniswapV2PairPriceFeedReturnType = {
   uniswapV2PairPriceFeed: UniswapV2PairPriceFeed;
   uniswapV2Pair: MockContract;
-}
+  underlyingOracles: MockContract[];
+};
 
-export async function unitFixtureUniswapV2PairPriceFeed(signers: Signer[]): Promise<UnitFixtureUniswapV2PairPriceFeedReturnType> {
+export async function unitFixtureUniswapV2PairPriceFeed(
+  signers: Signer[],
+): Promise<UnitFixtureUniswapV2PairPriceFeedReturnType> {
   const deployer: Signer = signers[0];
 
   const uniswapV2Pair: MockContract = await deployStubUniswapV2Pair(deployer);
 
-  const underlyingOracles = await deployUnderlyingPriceFeeds(deployer);
+  const underlyingOracles = [await deployStubPriceFeed(deployer), await deployStubPriceFeed(deployer)];
 
   const uniswapV2PairPriceFeed: UniswapV2PairPriceFeed = await deployUniswapV2PairPriceFeed(
     deployer,
-    'WBTC-UNI/ETH',
+    "WBTC-UNI/USD",
     uniswapV2Pair.address,
     [underlyingOracles[0].address, underlyingOracles[1].address],
   );
 
-  return { uniswapV2PairPriceFeed, uniswapV2Pair };
+  return { uniswapV2PairPriceFeed, uniswapV2Pair, underlyingOracles };
 }
 
 type UnitFixtureBalanceSheetReturnType = {

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -5,11 +5,13 @@ import { unitTestChainlinkOperator } from "./chainlinkOperator/ChainlinkOperator
 import { unitTestFintroller } from "./fintroller/Fintroller";
 import { unitTestFyToken } from "./fyToken/FyToken";
 import { unitTestRedemptionPool } from "./redemptionPool/RedemptionPool";
+import { unitTestUniswapV2PairPriceFeed } from "./uniswapV2PairPriceFeed/UniswapV2PairPriceFeed";
 
 baseContext("Unit Tests", function () {
-  unitTestBalanceSheet();
-  unitTestChainlinkOperator();
-  unitTestFintroller();
-  unitTestFyToken();
-  unitTestRedemptionPool();
+  // unitTestBalanceSheet();
+  // unitTestChainlinkOperator();
+  // unitTestFintroller();
+  // unitTestFyToken();
+  // unitTestRedemptionPool();
+  unitTestUniswapV2PairPriceFeed();
 });

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -8,10 +8,10 @@ import { unitTestRedemptionPool } from "./redemptionPool/RedemptionPool";
 import { unitTestUniswapV2PairPriceFeed } from "./uniswapV2PairPriceFeed/UniswapV2PairPriceFeed";
 
 baseContext("Unit Tests", function () {
-  // unitTestBalanceSheet();
-  // unitTestChainlinkOperator();
-  // unitTestFintroller();
-  // unitTestFyToken();
-  // unitTestRedemptionPool();
+  unitTestBalanceSheet();
+  unitTestChainlinkOperator();
+  unitTestFintroller();
+  unitTestFyToken();
+  unitTestRedemptionPool();
   unitTestUniswapV2PairPriceFeed();
 });

--- a/test/unit/stubs.ts
+++ b/test/unit/stubs.ts
@@ -55,6 +55,12 @@ export async function deployStubErc20(
   return erc20;
 }
 
+export async function deployStubUniswapV2Pair(deployer: Signer): Promise<MockContract> {
+  const simpleUniswapV2PairArtifact: Artifact = await hre.artifacts.readArtifact("SimpleUniswapV2Pair");
+  const uniswapV2Pair: MockContract = await deployStubContract(deployer, simpleUniswapV2PairArtifact.abi);
+  return uniswapV2Pair;
+}
+
 export async function deployStubFintroller(deployer: Signer): Promise<MockContract> {
   const fintrollerArtifact: Artifact = await hre.artifacts.readArtifact("Fintroller");
   const fintroller: MockContract = await deployStubContract(deployer, fintrollerArtifact.abi);

--- a/test/unit/stubs.ts
+++ b/test/unit/stubs.ts
@@ -118,6 +118,20 @@ export async function stubIsVaultOpen(this: Mocha.Context, fyTokenAddress: strin
   await this.stubs.balanceSheet.mock.isVaultOpen.withArgs(fyTokenAddress, account).returns(true);
 }
 
+export async function stubUniswapV2Pair(
+  this: Mocha.Context,
+  totalSupply: BigNumber,
+  reserve0: BigNumber,
+  reserve1: BigNumber,
+  price0: BigNumber,
+  price1: BigNumber,
+): Promise<void> {
+  await this.stubs.uniswapV2Pair.mock.totalSupply.returns(totalSupply);
+  await this.stubs.uniswapV2Pair.mock.getReserves.returns(reserve0, reserve1, 0);
+  await this.stubs.underlyingOracles[0].mock.latestRoundData.returns(Zero, price0, Zero, Zero, Zero);
+  await this.stubs.underlyingOracles[1].mock.latestRoundData.returns(Zero, price1, Zero, Zero, Zero);
+}
+
 export async function stubVaultFreeCollateral(
   this: Mocha.Context,
   fyTokenAddress: string,

--- a/test/unit/stubs.ts
+++ b/test/unit/stubs.ts
@@ -61,6 +61,13 @@ export async function deployStubUniswapV2Pair(deployer: Signer): Promise<MockCon
   return uniswapV2Pair;
 }
 
+export async function deployStubPriceFeed(deployer: Signer): Promise<MockContract> {
+  const simplePriceFeedArtifact: Artifact = await hre.artifacts.readArtifact("SimplePriceFeed");
+  const collateralPriceFeed: MockContract = await deployStubContract(deployer, simplePriceFeedArtifact.abi);
+  await collateralPriceFeed.mock.decimals.returns(chainlinkPricePrecision);
+  return collateralPriceFeed;
+}
+
 export async function deployStubFintroller(deployer: Signer): Promise<MockContract> {
   const fintrollerArtifact: Artifact = await hre.artifacts.readArtifact("Fintroller");
   const fintroller: MockContract = await deployStubContract(deployer, fintrollerArtifact.abi);

--- a/test/unit/uniswapV2PairPriceFeed/UniswapV2PairPriceFeed.behavior.ts
+++ b/test/unit/uniswapV2PairPriceFeed/UniswapV2PairPriceFeed.behavior.ts
@@ -1,0 +1,9 @@
+import shouldBehaveLikeUniswapV2PairPriceFeedGetter from "./view/uniswapV2PairPriceFeed";
+
+export function shouldBehaveLikeUniswapV2PairPriceFeed(): void {
+  describe("View functions", function () {
+    describe("uniswapV2PairPriceFeed", function () {
+      shouldBehaveLikeUniswapV2PairPriceFeedGetter();
+    });
+  });
+}

--- a/test/unit/uniswapV2PairPriceFeed/UniswapV2PairPriceFeed.ts
+++ b/test/unit/uniswapV2PairPriceFeed/UniswapV2PairPriceFeed.ts
@@ -1,0 +1,15 @@
+import { shouldBehaveLikeUniswapV2PairPriceFeed } from "./UniswapV2PairPriceFeed.behavior";
+import { unitFixtureUniswapV2PairPriceFeed } from "../fixtures";
+
+export function unitTestUniswapV2PairPriceFeed(): void {
+  describe("UniswapV2Pair", function () {
+    beforeEach(async function () {
+      const { uniswapV2PairPriceFeed, uniswapV2Pair } = await this.loadFixture(unitFixtureUniswapV2PairPriceFeed);
+
+      this.contracts.uniswapV2PairPriceFeed = uniswapV2PairPriceFeed;
+      this.stubs.uniswapV2Pair = uniswapV2Pair;
+    });
+
+    shouldBehaveLikeUniswapV2PairPriceFeed();
+  });
+}

--- a/test/unit/uniswapV2PairPriceFeed/UniswapV2PairPriceFeed.ts
+++ b/test/unit/uniswapV2PairPriceFeed/UniswapV2PairPriceFeed.ts
@@ -4,10 +4,12 @@ import { unitFixtureUniswapV2PairPriceFeed } from "../fixtures";
 export function unitTestUniswapV2PairPriceFeed(): void {
   describe("UniswapV2Pair", function () {
     beforeEach(async function () {
-      const { uniswapV2PairPriceFeed, uniswapV2Pair } = await this.loadFixture(unitFixtureUniswapV2PairPriceFeed);
-
+      const { uniswapV2PairPriceFeed, uniswapV2Pair, underlyingOracles } = await this.loadFixture(
+        unitFixtureUniswapV2PairPriceFeed,
+      );
       this.contracts.uniswapV2PairPriceFeed = uniswapV2PairPriceFeed;
       this.stubs.uniswapV2Pair = uniswapV2Pair;
+      this.stubs.underlyingOracles = underlyingOracles;
     });
 
     shouldBehaveLikeUniswapV2PairPriceFeed();

--- a/test/unit/uniswapV2PairPriceFeed/view/uniswapV2PairPriceFeed.ts
+++ b/test/unit/uniswapV2PairPriceFeed/view/uniswapV2PairPriceFeed.ts
@@ -1,16 +1,41 @@
 import { expect } from "chai";
 import { BigNumber } from "@ethersproject/bignumber";
+import { Zero } from "@ethersproject/constants";
 
 export default function shouldBehaveLikeUniswapV2PairPriceFeedGetter(): void {
-  it("retrives the description", async function () {
-    expect(await this.contracts.uniswapV2PairPriceFeed.description()).to.equal("WBTC-UNI/ETH");
+  it("returns the description", async function () {
+    expect(await this.contracts.uniswapV2PairPriceFeed.description()).to.equal("WBTC-UNI/USD");
   });
 
-  it("retrives the decimals", async function () {
+  it("returns the decimals", async function () {
     expect(await this.contracts.uniswapV2PairPriceFeed.decimals()).to.equal(BigNumber.from(8));
   });
 
-  it("retrives the version", async function () {
+  it("returns the version", async function () {
     expect(await this.contracts.uniswapV2PairPriceFeed.version()).to.equal(BigNumber.from(1));
+  });
+
+  it("returns the correct LP token price", async function () {
+    const totalSupplyGiven = BigNumber.from("201971551515601793370");
+    const reserve0Given = BigNumber.from("1121516254214");
+    const reserve1Given = BigNumber.from("7819315255132");
+    const price0Given = BigNumber.from("52135712522441353");
+    const price1Given = BigNumber.from("16112335453355156");
+
+    const priceExpected = BigNumber.from(
+      Math.trunc(
+        (2 * Math.sqrt(Number(reserve0Given.mul(reserve1Given))) * Math.sqrt(Number(price0Given.mul(price1Given)))) /
+          Number(totalSupplyGiven),
+      ) + "",
+    );
+
+    await this.stubs.uniswapV2Pair.mock.totalSupply.returns(totalSupplyGiven);
+    await this.stubs.uniswapV2Pair.mock.getReserves.returns(reserve0Given, reserve1Given, 0);
+    await this.stubs.underlyingOracles[0].mock.latestRoundData.returns(Zero, price0Given, Zero, Zero, Zero);
+    await this.stubs.underlyingOracles[1].mock.latestRoundData.returns(Zero, price1Given, Zero, Zero, Zero);
+
+    const latestRoundData = await this.contracts.uniswapV2PairPriceFeed.latestRoundData();
+
+    expect(latestRoundData.answer).to.equal(priceExpected);
   });
 }

--- a/test/unit/uniswapV2PairPriceFeed/view/uniswapV2PairPriceFeed.ts
+++ b/test/unit/uniswapV2PairPriceFeed/view/uniswapV2PairPriceFeed.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { BigNumber } from "@ethersproject/bignumber";
-import { Zero } from "@ethersproject/constants";
+import { UniswapV2PairPriceFeedErrors } from "../../../../helpers/errors";
+import { stubUniswapV2Pair } from "../../stubs";
 
 export default function shouldBehaveLikeUniswapV2PairPriceFeedGetter(): void {
   it("returns the description", async function () {
@@ -29,13 +30,54 @@ export default function shouldBehaveLikeUniswapV2PairPriceFeedGetter(): void {
       ) + "",
     );
 
-    await this.stubs.uniswapV2Pair.mock.totalSupply.returns(totalSupplyGiven);
-    await this.stubs.uniswapV2Pair.mock.getReserves.returns(reserve0Given, reserve1Given, 0);
-    await this.stubs.underlyingOracles[0].mock.latestRoundData.returns(Zero, price0Given, Zero, Zero, Zero);
-    await this.stubs.underlyingOracles[1].mock.latestRoundData.returns(Zero, price1Given, Zero, Zero, Zero);
+    await stubUniswapV2Pair.call(this, totalSupplyGiven, reserve0Given, reserve1Given, price0Given, price1Given);
 
     const latestRoundData = await this.contracts.uniswapV2PairPriceFeed.latestRoundData();
 
     expect(latestRoundData.answer).to.equal(priceExpected);
+  });
+
+  describe("reverts on math errors", function () {
+    it("p0*p1 overflow", async function () {
+      const totalSupplyGiven = BigNumber.from("201971551515601793370");
+      const reserve0Given = BigNumber.from("1121516254214");
+      const reserve1Given = BigNumber.from("7819315255132");
+      const price0Given = BigNumber.from("521357125224413235352135712213352244135443521357125222441353135712522441353");
+      const price1Given = BigNumber.from("161123354533551561611233545312343551561226112332345453355156233545335515621");
+
+      await stubUniswapV2Pair.call(this, totalSupplyGiven, reserve0Given, reserve1Given, price0Given, price1Given);
+
+      await expect(this.contracts.uniswapV2PairPriceFeed.latestRoundData()).to.be.revertedWith(
+        UniswapV2PairPriceFeedErrors.LatestRoundDataMathError,
+      );
+    });
+
+    it("sqrt(r0*r1)*sqrt(p0*p1) overflow", async function () {
+      const totalSupplyGiven = BigNumber.from("201971551515601793370");
+      const reserve0Given = BigNumber.from("1121516254214");
+      const reserve1Given = BigNumber.from("7819315255132");
+      const price0Given = BigNumber.from("521357125224413535213571252244135352135712522441353");
+      const price1Given = BigNumber.from("161123354533551561611233545335515616112335453355156");
+
+      await stubUniswapV2Pair.call(this, totalSupplyGiven, reserve0Given, reserve1Given, price0Given, price1Given);
+
+      await expect(this.contracts.uniswapV2PairPriceFeed.latestRoundData()).to.be.revertedWith(
+        UniswapV2PairPriceFeedErrors.LatestRoundDataMathError,
+      );
+    });
+
+    it("2*sqrt(r0*r1)*sqrt(p0*p1) overflow", async function () {
+      const totalSupplyGiven = BigNumber.from("201971551515601793370");
+      const reserve0Given = BigNumber.from("1121516254214");
+      const reserve1Given = BigNumber.from("7819315255132");
+      const price0Given = BigNumber.from("5213571252244135352135712522441353521357125224413");
+      const price1Given = BigNumber.from("1611233545335515616112335453355156161123354533551");
+
+      await stubUniswapV2Pair.call(this, totalSupplyGiven, reserve0Given, reserve1Given, price0Given, price1Given);
+
+      await expect(this.contracts.uniswapV2PairPriceFeed.latestRoundData()).to.be.revertedWith(
+        UniswapV2PairPriceFeedErrors.LatestRoundDataMathError,
+      );
+    });
   });
 }

--- a/test/unit/uniswapV2PairPriceFeed/view/uniswapV2PairPriceFeed.ts
+++ b/test/unit/uniswapV2PairPriceFeed/view/uniswapV2PairPriceFeed.ts
@@ -1,0 +1,16 @@
+import { expect } from "chai";
+import { BigNumber } from "@ethersproject/bignumber";
+
+export default function shouldBehaveLikeUniswapV2PairPriceFeedGetter(): void {
+  it("retrives the description", async function () {
+    expect(await this.contracts.uniswapV2PairPriceFeed.description()).to.equal("WBTC-UNI/ETH");
+  });
+
+  it("retrives the decimals", async function () {
+    expect(await this.contracts.uniswapV2PairPriceFeed.decimals()).to.equal(BigNumber.from(8));
+  });
+
+  it("retrives the version", async function () {
+    expect(await this.contracts.uniswapV2PairPriceFeed.version()).to.equal(BigNumber.from(1));
+  });
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -59,6 +59,7 @@ export interface Stubs {
   underlying: MockContract;
   underlyingPriceFeed: MockContract;
   uniswapV2Pair: MockContract;
+  underlyingOracles: MockContract[];
 }
 
 export interface Vault {

--- a/types/index.ts
+++ b/types/index.ts
@@ -12,6 +12,7 @@ import { GodModeRedemptionPool } from "../typechain/GodModeRedemptionPool";
 import { GodModeFyToken } from "../typechain/GodModeFyToken";
 import { RedemptionPool } from "../typechain/RedemptionPool";
 import { SimplePriceFeed } from "../typechain/SimplePriceFeed";
+import { UniswapV2PairPriceFeed } from "../typechain/UniswapV2PairPriceFeed";
 
 /* Fingers-crossed that ethers.js or waffle will provide an easier way to cache the address */
 export interface Accounts {
@@ -35,6 +36,7 @@ export interface Contracts {
   redemptionPool: GodModeRedemptionPool | RedemptionPool;
   underlying: Erc20Mintable;
   underlyingPriceFeed: SimplePriceFeed;
+  uniswapV2PairPriceFeed: UniswapV2PairPriceFeed;
 }
 
 export interface Signers {
@@ -56,6 +58,7 @@ export interface Stubs {
   redemptionPool: MockContract;
   underlying: MockContract;
   underlyingPriceFeed: MockContract;
+  uniswapV2Pair: MockContract;
 }
 
 export interface Vault {


### PR DESCRIPTION
Underlying assets in the Uniswap pool must both have USD-quoted Chainlink price feeds.

Crazy idea: Instead of passing in the underlying oracles as constructor arguments, we use ChainlinkOperator as the single source of truth and extract token0 and token1 addresses from the pair token contract. Disadvantage is that this way things get a little unpredictable and we'll need to test any newly added token.

TODO: add integrations tests